### PR TITLE
transformer_lm_mixin: softly ignore lack of VIS_DATASET_FILTER

### DIFF
--- a/main.py
+++ b/main.py
@@ -53,6 +53,7 @@ def register_args(parser: framework.helpers.ArgumentParser):
     parser.add_argument("-log_grad_norms", default=False)
     parser.add_argument("-n_microbatch", default="none", parser=parser.int_or_none_parser)
     parser.add_argument("-dump_logs", default=False)
+    parser.add_argument("-dump_validation_plots", default=False)
     parser.add_argument("-val_log_details", default=False)
     parser.add_argument("-nan_detect", default=False)
 

--- a/tasks/simple/language_model/transformer_lm_mixin.py
+++ b/tasks/simple/language_model/transformer_lm_mixin.py
@@ -353,9 +353,8 @@ class TransformerLMMixin:
         ]
 
     def validate_on_name(self, name: str) -> Tuple[Any, float]:
-        if (getattr(self, 'VIS_DATASET_FILTER', None) is None) or (name in self.VIS_DATASET_FILTER):
-            self.validation_started_on = name
-            self.validation_step = 0
+        self.validation_started_on = name
+        self.validation_step = 0
 
         return super().validate_on_name(name)
 

--- a/tasks/simple/language_model/transformer_lm_mixin.py
+++ b/tasks/simple/language_model/transformer_lm_mixin.py
@@ -353,7 +353,7 @@ class TransformerLMMixin:
         ]
 
     def validate_on_name(self, name: str) -> Tuple[Any, float]:
-        if (self.VIS_DATASET_FILTER is None) or (name in self.VIS_DATASET_FILTER):
+        if (getattr(self, 'VIS_DATASET_FILTER', None) is None) or (name in self.VIS_DATASET_FILTER):
             self.validation_started_on = name
             self.validation_step = 0
 


### PR DESCRIPTION
Hi Robert, love your setup, running `wandb sweep` + `wandb agent` is a neat way to reproduce everything and I'd love to adopt this.


I've hit a small problem running enwik8:

```
  File "/home/proger/moe_attention/main.py", line 110, in <module>                                                                   
    main()                                                                                                                           
  File "/home/proger/moe_attention/main.py", line 97, in main                                                                        
    task.train()                                                                                                                     
  File "/home/proger/moe_attention/tasks/simple/language_model/enwik8_transformer.py", line 90, in train                             
    super().train()                                                                                                                  
  File "/home/proger/moe_attention/tasks/simple/simple_task.py", line 339, in train                                                  
    plots.update(self.plot(res))                                                                                                     
  File "/home/proger/moe_attention/tasks/simple/simple_task.py", line 310, in plot                                                   
    res = super().plot(res)                                                                                                          
  File "/home/proger/moe_attention/tasks/task.py", line 295, in plot                                                                 
    plots.update({f"validation/{k}": v for k, v in self.validate().items()})                                                         
  File "/home/proger/moe_attention/tasks/task.py", line 269, in validate                                                             
    return self.validate_on_names(self.valid_sets.keys())                                                                            
  File "/home/proger/moe_attention/tasks/task.py", line 248, in validate_on_names                                                    
    test, loss = self.validate_on_name(name)                                                                                         
  File "/home/proger/moe_attention/tasks/simple/language_model/transformer_lm_mixin.py", line 356, in validate_on_name               
    if (self.VIS_DATASET_FILTER is None) or (name in self.VIS_DATASET_FILTER):                                                       
AttributeError: 'Enwik8Transformer' object has no attribute 'VIS_DATASET_FILTER'                                                     
```

The PR switches the check to getattr.